### PR TITLE
Update python before building mss

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN conda install conda-build -y
 
 # fetch localbuild from mss branch develop, build and install mss, cleanup
 RUN wget https://github.com/Open-MSS/MSS/archive/develop.tar.gz \
+  && conda update python \
   && mkdir /localbuild \
   && tar -C /localbuild --strip-components=2 -xvf develop.tar.gz MSS-develop/localbuild \
   && sed -i "s@path: ../@git_url: https://github.com/Open-MSS/MSS.git\n  git_tag: develop@" /localbuild/meta.yaml \


### PR DESCRIPTION
Python 3.8 seems to be causing issues in our images lately. I mentioned that here as well
https://github.com/Open-MSS/MSS/issues/669#issuecomment-779191080

Updating to Python 3.9 gets rid of that.