### PR TITLE
Update package list for newest xvfb

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,7 @@ jobs:
           git checkout develop &&
           source /opt/conda/bin/activate mssenv &&
           mamba install --file requirements.d/development.txt &&
+          echo 'deb http://ftp.us.debian.org/debian testing main contrib non-free' >> /etc/apt/sources.list &&
           apt-get update &&
           apt-get install xvfb -y &&
           mamba install pyvirtualdisplay &&


### PR DESCRIPTION
The package list of apt is outdated per default in the image, the xvfb version installed before does not work with QT >5.9 and causes BUS errors eventually.
Update the apt sources list to get the newest xvfb and the issues while testing go away.